### PR TITLE
Add log prefix to ingested logs

### DIFF
--- a/lib/logstash/inputs/cloudwatch_logs.rb
+++ b/lib/logstash/inputs/cloudwatch_logs.rb
@@ -7,6 +7,7 @@ require 'stud/interval'
 require 'aws-sdk'
 require 'logstash/inputs/cloudwatch_logs/patch'
 require 'fileutils'
+require 'rubygems'
 
 Aws.eager_autoload!
 
@@ -52,13 +53,14 @@ class LogStash::Inputs::CloudWatch_Logs < LogStash::Inputs::Base
   def register
     require 'digest/md5'
     @logger.debug('Registering cloudwatch_logs input', :log_group => @log_group)
+    spec = Gem::Specification.load('logstash-input-cloudwatch_logs.gemspec')
     settings = defined?(LogStash::SETTINGS) ? LogStash::SETTINGS : nil
     @sincedb = {}
-    @logger.info("version 1.1.1")
+    @logger.info("version #{spec.version}")
     check_start_position_validity
     @cloudwatch = Aws::CloudWatchLogs::Client.new(aws_options_hash)
     @tag_cache = {}
-    @logger.info("starting Cache")
+    @logger.info('starting cache')
     Aws::ConfigService::Client.new(aws_options_hash)
 
     if @sincedb_path.nil?

--- a/lib/logstash/inputs/cloudwatch_logs.rb
+++ b/lib/logstash/inputs/cloudwatch_logs.rb
@@ -236,6 +236,7 @@ class LogStash::Inputs::CloudWatch_Logs < LogStash::Inputs::Base
       event.set('[cloudwatch_logs][log_stream]', log.log_stream_name)
       event.set('[cloudwatch_logs][event_id]', log.event_id)
       event.set('[cloudwatch_logs][tags]', tags)
+      event.set('[cloudwatch_logs][log_group_prefix]', @log_group_prefix)
       decorate(event)
 
       @queue << event


### PR DESCRIPTION
## Changes proposed in this pull request:

- Load gem version from gem spec for info message
- Add log group prefix as `[cloudwatch_logs][log_group_prefix]` on ingested logs, which will make logs easier to search

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just improving searchability of ingested cloudwatch logs
