### PR TITLE
update code for loading gem version dynamically

### DIFF
--- a/lib/logstash/inputs/cloudwatch_logs.rb
+++ b/lib/logstash/inputs/cloudwatch_logs.rb
@@ -9,8 +9,6 @@ require 'logstash/inputs/cloudwatch_logs/patch'
 require 'fileutils'
 require 'rubygems'
 
-Aws.eager_autoload!
-
 # Stream events from CloudWatch Logs streams.
 #
 # Specify an individual log group, and this plugin will scan
@@ -53,10 +51,9 @@ class LogStash::Inputs::CloudWatch_Logs < LogStash::Inputs::Base
   def register
     require 'digest/md5'
     @logger.debug('Registering cloudwatch_logs input', :log_group => @log_group)
-    spec = Gem::Specification.load('logstash-input-cloudwatch_logs.gemspec')
     settings = defined?(LogStash::SETTINGS) ? LogStash::SETTINGS : nil
     @sincedb = {}
-    @logger.info("version #{spec.version}")
+    @logger.info("version #{Gem.loaded_specs['logstash-input-cloudwatch_logs'].version}")
     check_start_position_validity
     @cloudwatch = Aws::CloudWatchLogs::Client.new(aws_options_hash)
     @tag_cache = {}

--- a/logstash-input-cloudwatch_logs.gemspec
+++ b/logstash-input-cloudwatch_logs.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '= 3.1.4'
 
   s.name            = 'logstash-input-cloudwatch_logs'
-  s.version         = '1.1.2'
+  s.version         = '1.1.3'
   s.licenses        = ['Apache-2.0']
   s.summary         = 'Stream events from CloudWatch Logs.'
   s.description     = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline'\


### PR DESCRIPTION
## Changes proposed in this pull request:

- update code for loading gem version dynamically to address runtime error. As is, the plugin is failing to start with `NoMethodError: undefined method `version' for nil:NilClass`
- Remove `Aws.eager_autoload!` [since it is deprecated in Ruby aws-sdk-core > 3](https://github.com/aws/aws-sdk-ruby/blob/version-3/UPGRADING.md)

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just changing method for loading gem version dynamically
