### PR TITLE
update log_type field to be ignored if value is nil

### DIFF
--- a/lib/logstash/inputs/cloudwatch_logs.rb
+++ b/lib/logstash/inputs/cloudwatch_logs.rb
@@ -173,8 +173,6 @@ class LogStash::Inputs::CloudWatch_Logs < LogStash::Inputs::Base
       'opensearch'
     when %r{/aws/ElasticCache/.*}i
       'elasticache'
-    else
-      'unknown log type'
     end
   end
 
@@ -248,7 +246,7 @@ class LogStash::Inputs::CloudWatch_Logs < LogStash::Inputs::Base
       event.set('[cloudwatch_logs][log_stream]', log.log_stream_name)
       event.set('[cloudwatch_logs][event_id]', log.event_id)
       event.set('[cloudwatch_logs][tags]', tags)
-      event.set('[cloudwatch_logs][log_type]', log_type)
+      event.set('[cloudwatch_logs][log_type]', log_type) unless log_type.nil?
       decorate(event)
 
       @queue << event


### PR DESCRIPTION
## Changes proposed in this pull request:

- update log_type field to be ignored if value is nil

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just changing logic for detecting and setting a `log_type` property for incoming logs
